### PR TITLE
add support for xiaomi.gateway.hub1

### DIFF
--- a/custom_components/xiaomi_miot/core/device_customizes.py
+++ b/custom_components/xiaomi_miot/core/device_customizes.py
@@ -1214,6 +1214,9 @@ DEVICE_CUSTOMIZES = {
         'button_actions': 'wake_up,play_music,tv_switchon,stop_alarm',
         'text_actions': 'play_text,execute_text_directive',
     },
+    'xiaomi.gateway.hub1': {
+        'sensor_properties': 'ip_address,wifi_ssid',
+    },
     'xjx.toilet.relaxp': {
         'sensor_properties': 'status',
         'switch_properties': 'status_seatheat,status_led,auto_led,switch_bubble,status_seat,status_cover,'

--- a/custom_components/xiaomi_miot/sensor.py
+++ b/custom_components/xiaomi_miot/sensor.py
@@ -103,7 +103,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             'cooker', 'induction_cooker', 'pressure_cooker', 'air_fryer', 'juicer',
             'water_purifier', 'dishwasher', 'fruit_vegetable_purifier',
             'pet_feeder', 'cat_toilet', 'fridge_chamber', 'plant_monitor', 'germicidal_lamp', 'vital_signs',
-            'sterilizer', 'steriliser', 'table', 'chair', 'dryer', 'clothes_dryer',
+            'sterilizer', 'steriliser', 'table', 'chair', 'dryer', 'clothes_dryer', 'gateway',
         ):
             if srv.name in ['lock']:
                 if not srv.get_property('operation_method', 'operation_id'):


### PR DESCRIPTION
能发布虚拟事件，但目前没法监听
```yaml
service: xiaomi_miot.call_action
data:
  throw: true
  entity_id: sensor.xiaomi_hub1_xxxx_gateway
  aiid: 1
  siid: 4
  params: 测试接收触发事件
```